### PR TITLE
Fixes timer duplication

### DIFF
--- a/src/features/timer/Timer.tsx
+++ b/src/features/timer/Timer.tsx
@@ -21,12 +21,14 @@ export const Timer = () => {
   const resetTimer = () => dispatch(timerState.resetTimer());
 
   const startTimer = () => {
-    const intervalID = setInterval(() => {
-      if (currentState.minutes > 0 || currentState.seconds > 0) tick();
-      else stopTimer();
-    }, 1000);
+    if (!currentState.isTimerActive) {
+      const intervalID = setInterval(() => {
+        if (currentState.minutes > 0 || currentState.seconds > 0) tick();
+        else stopTimer();
+      }, 1000);
 
-    dispatch(timerState.startTimer(intervalID));
+      dispatch(timerState.startTimer(intervalID));
+    }
   };
 
   const selectMode = (mode: 'work' | 'shortBreak' | 'longBreak') =>


### PR DESCRIPTION
You could mash the start button and cause multiple timer intervals. This just adds a check to see if the timer is active before starting.