### PR TITLE
Fixes issue with subshell string

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -7,10 +7,14 @@ version=`head -n 1 CHANGELOG.md | cut -c4-`
 echo "running production build"
 npm run build
 
+echo "staging build results"
+git add dist/
+git add CHANGELOG.md
+
 echo "creating v$version"
 # `-f` flag used to force inclusion of `CHANGELOG.md` changes
 npm version -f $version
 
-echo "ready for push with `git push main` and `git push --tags`"
+echo "ready for push with git push main and git push --tags"
 
 unset NODE_ENV


### PR DESCRIPTION
I wrote an echo with my brain in markdown mode to show commands and forgot that format in bash executes that command.

Also added a step to stage the `dist/` folder and changelog before creating the release commit.